### PR TITLE
Create a github action for branch master.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,46 @@
+name: Build Electron App
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install electron
+        run: npm install electron --save-dev
+
+      - name: Install electron-packager
+        run: npm install electron-packager --save-dev
+
+      - name: Build linux-64
+        run: npm run package-linux64
+
+      - name: Upload artifact linux-64
+        uses: actions/upload-artifact@v4
+        with:
+          name: sqlite3-page-explorer-linux-x64
+          path: release-builds/sqlite3-page-explorer-linux-x64
+
+      - name: Install wine
+        run: sudo apt install -y wine
+
+      - name: Build win32
+        run: npm run package-win32
+
+      - name: Upload artifact win32
+        uses: actions/upload-artifact@v4
+        with:
+          name: sqlite3-page-explorer-win32-ia32
+          path: release-builds/sqlite3-page-explorer-win32-ia32


### PR DESCRIPTION
This will build win32 and linux64 packages, and upload them as artifacts.

This can be useful if someone only wants to download the compiled file and doesn't want to install electron.